### PR TITLE
Update Exercise 29b — Beyond the exercise.ipynb

### DIFF
--- a/chapter-06/Exercise 29b — Beyond the exercise.ipynb
+++ b/chapter-06/Exercise 29b — Beyond the exercise.ipynb
@@ -412,7 +412,7 @@
    "source": [
     "df.sort_values('trip_distance',\n",
     "                ascending=False,\n",
-    "              ignore_index=True)['total_amount'].loc[:20].mean()\n"
+    "              ignore_index=True)['total_amount'].loc[:19].mean()\n"
    ]
   },
   {


### PR DESCRIPTION
Using `loc` selects rows with index labels from 0 up to and including 19. This gives you 20 rows.